### PR TITLE
Исправлено некорректное создание маски в случае, если номер содержит только две части

### DIFF
--- a/amd/useMaskedPhoneInput.js
+++ b/amd/useMaskedPhoneInput.js
@@ -49,9 +49,9 @@ define(["require", "exports", "react", "libphonenumber-js", "libphonenumber-js/e
             .formatInternational()
             .replace(/-/g, " ")
             .split(" ")
-            .map(function (item, i) {
+            .map(function (item, i, items) {
             var mask = item.replace(/\D/g, "").replace(/\d/g, "0");
-            return i === 1 ? "([" + mask + "])" : "[" + mask + "]";
+            return items.length > 2 && i === 1 ? "([" + mask + "])" : "[" + mask + "]";
         });
     };
     var getCountryMaskBycode = function (code, defaultMask) {

--- a/es/useMaskedPhoneInput.js
+++ b/es/useMaskedPhoneInput.js
@@ -27,9 +27,9 @@ var getParsedMask = function (example) {
         .formatInternational()
         .replace(/-/g, " ")
         .split(" ")
-        .map(function (item, i) {
+        .map(function (item, i, items) {
         var mask = item.replace(/\D/g, "").replace(/\d/g, "0");
-        return i === 1 ? "([" + mask + "])" : "[" + mask + "]";
+        return items.length > 2 && i === 1 ? "([" + mask + "])" : "[" + mask + "]";
     });
 };
 var getCountryMaskBycode = function (code, defaultMask) {

--- a/lib/useMaskedPhoneInput.js
+++ b/lib/useMaskedPhoneInput.js
@@ -52,9 +52,9 @@ var getParsedMask = function (example) {
         .formatInternational()
         .replace(/-/g, " ")
         .split(" ")
-        .map(function (item, i) {
+        .map(function (item, i, items) {
         var mask = item.replace(/\D/g, "").replace(/\d/g, "0");
-        return i === 1 ? "([" + mask + "])" : "[" + mask + "]";
+        return items.length > 2 && i === 1 ? "([" + mask + "])" : "[" + mask + "]";
     });
 };
 var getCountryMaskBycode = function (code, defaultMask) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@alexzunik/rn-easy-phone-input-mask",
-    "version": "0.1.7",
+    "version": "0.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/useMaskedPhoneInput.tsx
+++ b/src/useMaskedPhoneInput.tsx
@@ -49,9 +49,9 @@ const getParsedMask = (example: PhoneNumber) => {
         .formatInternational()
         .replace(/-/g, " ")
         .split(" ")
-        .map((item, i) => {
+        .map((item, i, items) => {
             const mask = item.replace(/\D/g, "").replace(/\d/g, "0");
-            return i === 1 ? `([${mask}])` : `[${mask}]`
+            return items.length > 2 && i === 1 ? `([${mask}])` : `[${mask}]`
         })
 }
 


### PR DESCRIPTION
Исправлено некорректное создание маски в случае, если номер содержит только две части: код страны и остальной набор цифр. Например, "+62 12312312312". Текущий код преобразует это к следующей маске: "+00 (00000000000)", хотя нужно "+00 00000000000".